### PR TITLE
Removing last line break from clipboard

### DIFF
--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -513,7 +513,7 @@ export const DataSheetGrid = React.memo(
           const pasteData =
             event.clipboardData
               ?.getData('text')
-              .replace(/\r/g, '')
+              .replace(/\r|\n$/g, '')
               .split('\n')
               .map((row) => row.split('\t')) || []
 


### PR DESCRIPTION
This is a simple addition to remove the last new line from the clipboard. This last new line is creating a new row. See #39 