### PR TITLE
Move to ESM module, fix TS2345

### DIFF
--- a/src/contexts/SelectionContext.ts
+++ b/src/contexts/SelectionContext.ts
@@ -16,4 +16,5 @@ export const SelectionContext = React.createContext<SelectionContextType>({
   },
   editing: false,
   isCellDisabled: () => false,
+  expandSelection: null,
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
      "incremental": true,
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ES2015",
+    "module": "ES2020",
      "allowJs": false,
      "jsx": "react",
      "declaration": true,


### PR DESCRIPTION
Hi.

I tried to use this library with https://vitejs.dev/
It is dont work by default (import and other errors).

If we change module settings in tsconfig.json - all works:
"target": "ES2015",
"module": "ES2020",

Also PR fixes small error TS2345 in SelectionContext.ts - absent expandSelection member in SelectionContext.