### PR TITLE
Small fixes for zoom out

### DIFF
--- a/src/components/DataSheetGrid.tsx
+++ b/src/components/DataSheetGrid.tsx
@@ -129,10 +129,10 @@ export const DataSheetGrid = React.memo(
         refreshRate: 100,
       })
 
-      setHeightDiff(height ? displayHeight - height : 0)
+      setHeightDiff(height ? displayHeight - Math.ceil(height) : 0)
 
       const edges = useEdges(outerRef, width, height)
-
+      
       const {
         fullWidth,
         totalWidth: contentWidth,

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -62,7 +62,7 @@ export const useColumnWidths = (
     children.forEach((child) => el.appendChild(child))
     document.body.insertBefore(el, null)
 
-    setColumnWidths(children.map((child) => child.offsetWidth))
+    setColumnWidths(children.map((child) => child.getBoundingClientRect().right - child.getBoundingClientRect().left))
     setPrevWidth(width)
 
     el.remove()
@@ -70,7 +70,7 @@ export const useColumnWidths = (
   }, [width, columnsHash])
 
   return {
-    fullWidth: prevWidth === totalWidth,
+    fullWidth: Math.abs((prevWidth ? prevWidth : 0) - (totalWidth ? totalWidth : 0)) < 0.1,
     columnWidths,
     columnRights,
     totalWidth,

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -62,7 +62,7 @@ export const useColumnWidths = (
     children.forEach((child) => el.appendChild(child))
     document.body.insertBefore(el, null)
 
-    setColumnWidths(children.map((child) => child.getBoundingClientRect().right - child.getBoundingClientRect().left))
+    setColumnWidths(children.map((child) => child.getBoundingClientRect().width))
     setPrevWidth(width)
 
     el.remove()

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -70,7 +70,7 @@ export const useColumnWidths = (
   }, [width, columnsHash])
 
   return {
-    fullWidth: Math.abs((prevWidth ? prevWidth : 0) - (totalWidth ? totalWidth : 0)) < 0.1,
+    fullWidth: Math.abs((prevWidth ?? 0) - (totalWidth ?? 0)) < 0.1,
     columnWidths,
     columnRights,
     totalWidth,

--- a/src/hooks/useEdges.ts
+++ b/src/hooks/useEdges.ts
@@ -19,11 +19,11 @@ export const useEdges = (
       setEdges({
         top: ref.current?.scrollTop === 0,
         right:
-          ref.current?.scrollLeft ===
-          (ref.current?.scrollWidth ?? 0) - (width ?? 0),
+          (ref.current?.scrollLeft ?? 0) >=
+          (ref.current?.scrollWidth ?? 0) - (width ?? 0) - 1,
         bottom:
-          ref.current?.scrollTop ===
-          (ref.current?.scrollHeight ?? 0) - (height ?? 0),
+          (ref.current?.scrollTop ?? 0) >=
+          (ref.current?.scrollHeight ?? 0) - (height ?? 0) - 1,
         left: ref.current?.scrollLeft === 0,
       })
     })


### PR DESCRIPTION
1. On specific zoom values and table heights table was endlessly rerendered (for example, first table on https://react-datasheet-grid.netlify.app/ with 4 rows and zoom 67% in Chrome).
2. On zoom levels less than 100% shadow was appeared on right and bottom edges of table.